### PR TITLE
Improve hover performance of box-shadow on rows

### DIFF
--- a/src/components/HoverWrapper.js
+++ b/src/components/HoverWrapper.js
@@ -6,23 +6,23 @@ import { shadows } from '../styles';
 const StyledHoverWrapper = styled.div`
   position: relative;
   width: 100%;
-  box-shadow: ${({ hover }) => (hover ? shadows.big : '0')};
   z-index: ${({ hover }) => (hover ? 20 : 0)};
-`;
 
-const StyledRelative = styled.div`
-  width: 100%;
-  position: relative;
-`;
-const StyledHover = styled.div`
-  width: 100%;
-  position: absolute;
+  &:before {
+    bottom: 0;
+    box-shadow: ${shadows.big};
+    content: " ";
+    left: 0;
+    opacity: ${({ hover }) => (hover ? 1 : 0)}
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 `;
 
 const HoverWrapper = ({ hover, children, ...props }) => (
   <StyledHoverWrapper hover={hover} {...props}>
-    <StyledHover hover={hover}>{children}</StyledHover>
-    <StyledRelative hover={hover}>{children}</StyledRelative>
+    {children}
   </StyledHoverWrapper>
 );
 


### PR DESCRIPTION
Fixes https://github.com/balance-io/balance-manager/issues/180

Performance improvement comes from:
1) Painting the `box-shadow` once, and then toggling the opacity of it on hover (painting box-shadows is like the slowest thing for a browser to do)
2) Only rendering row children nodes once, instead of twice