### PR TITLE
Add graphs for ETH and tokens. Add token info #214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 
-## [Unreleased]
+## [Unreleased] - 06.06.2018
 
 ### Added
+* Proxy server to communicate with external APIs
+* Add graphs from Binance
+* Add token info from Trivial
 
-*
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ yarn start
 npm run start
 ```
 
+```
+npm run start:dev
+```
+To start the proxy for querying Binance for graph data
+
 For production
 
 ```

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "eject": "react-scripts eject",
     "precommit": "lint-staged",
     "format": "prettier --write \"src/**/*.{js,json}\"",
-    "lint": "eslint src --ext .js"
+    "lint": "eslint src --ext .js",
+    "watch": "npm-watch"
   },
   "proxy": "http://localhost:5000",
   "lint-staged": {
@@ -79,5 +80,11 @@
     "lint-staged": "^7.1.0",
     "npm-watch": "^0.3.0",
     "prettier": "^1.12.1"
+  },
+  "watch": {
+    "start:dev": {
+      "patterns": "server",
+      "extensions": "js"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,13 +18,21 @@
     "axios": "^0.18.0",
     "bignumber.js": "^7.0.1",
     "ethereumjs-tx": "^1.3.4",
+    "fusioncharts": "^3.12.2",
+    "hapi": "^17.5.1",
     "i18next": "^11.3.2",
+    "inert": "^5.1.0",
     "jsonp": "^0.2.1",
     "lodash": "^4.17.5",
+    "lout": "^11.0.1",
+    "moment": "^2.22.2",
+    "pino": "^4.17.2",
+    "pino-colada": "^1.4.4",
     "prop-types": "^15.6.1",
     "qrcode": "^1.2.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-fusioncharts": "^1.0.5",
     "react-qr-reader": "^2.1.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
@@ -33,12 +41,14 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
     "styled-components": "^3.2.3",
+    "vision": "^5.3.2",
     "walletconnect": "^0.0.1-beta.11",
     "web3": "^1.0.0-beta.34"
   },
   "scripts": {
     "remove-sourcemaps": "rm -rf build/static/js/*.map",
     "start": "HTTPS=true NODE_ENV=development react-scripts start",
+    "start:dev": "node server | pino-colada",
     "build": "react-scripts build",
     "build:lambda": "netlify-lambda build src/lambda",
     "test": "react-scripts test --env=jsdom",
@@ -47,6 +57,7 @@
     "format": "prettier --write \"src/**/*.{js,json}\"",
     "lint": "eslint src --ext .js"
   },
+  "proxy": "http://localhost:5000",
   "lint-staged": {
     "src/**/*.js": [
       "eslint src --ext .js",
@@ -66,6 +77,7 @@
     "eslint-plugin-react": "^7.7.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.0",
+    "npm-watch": "^0.3.0",
     "prettier": "^1.12.1"
   }
 }

--- a/server/api.js
+++ b/server/api.js
@@ -39,7 +39,6 @@ const initialize = async server => {
       symbol.indexOf('EUR') !== -1 ||
       symbol.indexOf('USD') !== -1
     ) {
-
       return symbol.substr(0, 3) + 'USDT';
     }
     return symbol;
@@ -69,6 +68,34 @@ const initialize = async server => {
           // Other: probably no connection to Binance
           .catch(err => {
             // return [];
+            return h.response().code(404);
+          });
+        return response;
+      },
+    },
+  });
+
+  server.route({
+    method: 'get',
+    path: '/api/tokenInfo',
+    options: {
+      notes: 'Get candles for currency in 1 month intervals the last year',
+      handler: async (request, h) => {
+        console.log(
+          `https://trivial.co/api/tokeninformation?token_address=${
+            request.query.address
+          }`,
+        );
+        const response = await axios
+          .get(
+            `https://trivial.co/api/tokeninformation?token_address=${
+              request.query.address
+            }`,
+          )
+          .then(res => {
+            return res.data;
+          })
+          .catch(err => {
             return h.response().code(404);
           });
         return response;

--- a/server/api.js
+++ b/server/api.js
@@ -74,34 +74,6 @@ const initialize = async server => {
       },
     },
   });
-
-  server.route({
-    method: 'get',
-    path: '/api/tokenInfo',
-    options: {
-      notes: 'Get candles for currency in 1 month intervals the last year',
-      handler: async (request, h) => {
-        console.log(
-          `https://trivial.co/api/tokeninformation?token_address=${
-            request.query.address
-          }`,
-        );
-        const response = await axios
-          .get(
-            `https://trivial.co/api/tokeninformation?token_address=${
-              request.query.address
-            }`,
-          )
-          .then(res => {
-            return res.data;
-          })
-          .catch(err => {
-            return h.response().code(404);
-          });
-        return response;
-      },
-    },
-  });
 };
 
 module.exports = {

--- a/server/api.js
+++ b/server/api.js
@@ -1,0 +1,82 @@
+const Vision = require('vision');
+const Inert = require('inert');
+const Lout = require('lout');
+const axios = require('axios');
+const moment = require('moment');
+
+const initialize = async server => {
+  await server.register(Vision);
+  await server.register(Inert);
+  await server.register(Lout);
+
+  server.route({
+    method: 'get',
+    path: '/',
+    options: {
+      plugins: {
+        lout: false,
+      },
+      handler: async (request, h) => {
+        return h.redirect('/docs');
+      },
+    },
+  });
+
+  server.route({
+    method: 'get',
+    path: '/ping',
+    options: {
+      notes: 'Test connectivity to the Rest API',
+      handler: async (request, h) => {
+        return h.response({});
+      },
+    },
+  });
+
+  function filterNativeCurrencies(symbol) {
+    if (
+      symbol.indexOf('GBP') !== -1 ||
+      symbol.indexOf('EUR') !== -1 ||
+      symbol.indexOf('USD') !== -1
+    ) {
+
+      return symbol.substr(0, 3) + 'USDT';
+    }
+    return symbol;
+  }
+
+  server.route({
+    method: 'get',
+    path: '/candles/{symbol}',
+    options: {
+      notes: 'Get candles for currency in 1 month intervals the last year',
+      handler: async (request, h) => {
+        const symbol = filterNativeCurrencies(request.params.symbol);
+        const time = await axios.get('https://api.binance.com/api/v1/time');
+        const oneDayAgo = moment(time.data.serverTime)
+          .subtract(1, 'years')
+          .valueOf();
+
+        const response = await axios
+          .get(
+            `https://api.binance.com/api/v1/klines?symbol=${symbol}&interval=1M&startTime=${oneDayAgo}`,
+          )
+          .then(res => {
+            return res.data;
+          })
+          // Needs better handeling.
+          // 400: token not found
+          // Other: probably no connection to Binance
+          .catch(err => {
+            // return [];
+            return h.response().code(404);
+          });
+        return response;
+      },
+    },
+  });
+};
+
+module.exports = {
+  initialize,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,19 @@
+const Hapi = require('hapi');
+const log = require('pino')();
+
+const SERVER_PORT = 5000;
+
+async function start() {
+  try {
+    const server = Hapi.Server({
+      port: SERVER_PORT,
+    });
+    await require('./api').initialize(server);
+    server.start();
+    log.info(`Server running at port ${SERVER_PORT}`);
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+}
+start();

--- a/src/Router.js
+++ b/src/Router.js
@@ -36,12 +36,15 @@ Router.contextTypes = {
 };
 
 const reduxProps = ({ account }) => ({
-    language: account.language
+  language: account.language,
 });
 
 export default withRouter(
-  connect(reduxProps, {
-    warningOffline,
-    warningOnline,
-  })(Router),
+  connect(
+    reduxProps,
+    {
+      warningOffline,
+      warningOnline,
+    },
+  )(Router),
 );

--- a/src/components/CopyToClipboard.js
+++ b/src/components/CopyToClipboard.js
@@ -150,4 +150,7 @@ CopyToClipboard.defaultProps = {
   iconOnHover: false,
 };
 
-export default connect(null, { notificationShow })(CopyToClipboard);
+export default connect(
+  null,
+  { notificationShow },
+)(CopyToClipboard);

--- a/src/components/EthereumInfo.js
+++ b/src/components/EthereumInfo.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import { graphAddOpenGraph, graphRemoveOpenGraph } from '../reducers/_graph';
+import Graph from './Graph';
+import { colors } from '../styles';
+
+const StyledInfoContainer = styled.div`
+  background-color: ${colors.white}
+  grid-row-start: 2;
+  grid-column-end: span 5;
+  text-align: left;
+`;
+
+const StyledButton = styled.button`
+  font-size: 1rem;
+  display: block;
+  width: 100%;
+  background-color: rgb(${colors.lightGrey});
+`;
+
+class EthereumInfo extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleInfo = this.toggleInfo.bind(this);
+    this.state = {
+      open: false,
+    };
+  }
+
+  toggleInfo() {
+    const { open } = this.state;
+    const { symbol, graphAddOpenGraph, graphRemoveOpenGraph } = this.props;
+    if (!open) {
+      graphAddOpenGraph(symbol);
+    } else {
+      graphRemoveOpenGraph(symbol);
+    }
+
+    this.setState({
+      open: !open,
+    });
+  }
+
+  render() {
+    const { open } = this.state;
+    const { symbol } = this.props;
+
+    return (
+      <StyledInfoContainer>
+        <StyledButton onClick={this.toggleInfo}>
+          {open ? 'Hide' : 'Show'} more info
+        </StyledButton>
+        {open ? <Graph symbol={symbol} /> : ''}
+      </StyledInfoContainer>
+    );
+  }
+}
+
+export default connect(
+  null,
+  {
+    graphAddOpenGraph,
+    graphRemoveOpenGraph,
+  },
+)(EthereumInfo);

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import styled from 'styled-components';
 import FusionCharts from 'fusioncharts';
 import PowerCharts from 'fusioncharts/fusioncharts.powercharts';
 import ReactFC from 'react-fusioncharts';
@@ -13,43 +12,12 @@ import {
   graphRemoveOpenGraph,
 } from '../reducers/_graph';
 
-const StyledGraph = styled.div`
-  background-color: #fff;
-  grid-row-start: 2;
-  grid-column-end: span 5;
-`;
-
-const StyledButton = styled.button`
-  font-size: 1rem;
-`;
-
-const StyledGraphContainer = styled.div`
-  text-align: center;
-  padding: 10px;
-`;
-
 class Graph extends Component {
-  state = {
-    open: false,
-  };
-
-  constructor(props) {
-    super(props);
-    this.toggleGraph = this.toggleGraph.bind(this);
-    this.getGraphData = this.getGraphData.bind(this);
-  }
-
-  toggleGraph() {
-    const newOpenState = !this.state.open;
-    this.setState({
-      open: newOpenState,
-    });
-    if (newOpenState) {
-      this.props.graphAddOpenGraph(this.props.symbol);
-      this.getGraphData();
-    } else {
-      this.props.graphRemoveOpenGraph(this.props.symbol);
-    }
+  componentDidMount() {
+    this.props.graphGetCurrencyGraph(
+      this.props.symbol,
+      this.props.nativeCurrency,
+    );
   }
 
   getGraphData() {
@@ -60,63 +28,46 @@ class Graph extends Component {
   }
 
   render() {
-    const { open } = this.state;
     const { graph, nativeCurrency, symbol } = this.props;
 
-    function renderGraphContainer() {
-      function renderContainerContent() {
-        if (graph.fetching) {
-          return <Loader size={20} color="black" background="white" />;
-        }
-        if (graph.error) {
-          return <span>{graph.error.message}</span>;
-        }
-        PowerCharts(FusionCharts);
-
-        const myDataSource = {
-          chart: {
-            caption: symbol,
-            subCaption: `worth in ${
-              nativeCurrency === 'GBP' || nativeCurrency === 'EUR'
-                ? 'USD'
-                : nativeCurrency
-            }`,
-            showValues: '0',
-          },
-          data: graph.points.map(point => {
-            return {
-              value: point[2],
-              label: moment(point[0])
-                .format('M/D/YYYY')
-                .toString(),
-            };
-          }),
-        };
-
-        const chartConfigs = {
-          type: 'spline',
-          width: '100%',
-          height: '400px',
-          dataFormat: 'json',
-          dataSource: myDataSource,
-        };
-
-        return <ReactFC {...chartConfigs} />;
-      }
-
-      return (
-        <StyledGraphContainer>{renderContainerContent()}</StyledGraphContainer>
-      );
+    if (!graph) return <div />;
+    if (graph.fetching) {
+      return <Loader size={20} color="black" background="white" />;
+    }
+    if (graph.error) {
+      return <span>{graph.error.message}</span>;
     }
 
-    return (
-      <StyledGraph>
-        <StyledButton onClick={this.toggleGraph}>
-          {open ? 'Hide' : 'Show'} graph
-        </StyledButton>
-        {open ? renderGraphContainer() : ''}
-      </StyledGraph>
-    );
+    PowerCharts(FusionCharts);
+
+    const myDataSource = {
+      chart: {
+        caption: `${symbol} worth in ${
+          nativeCurrency === 'GBP' || nativeCurrency === 'EUR'
+            ? 'USD'
+            : nativeCurrency
+        }`,
+        showValues: '0',
+      },
+      data: graph.points.map(point => {
+        return {
+          value: point[2],
+          label: moment(point[0])
+            .format('M/D/YYYY')
+            .toString(),
+        };
+      }),
+    };
+
+    const chartConfigs = {
+      type: 'spline',
+      width: '95%',
+      height: '200px',
+      dataFormat: 'json',
+      dataSource: myDataSource,
+    };
+
+    return <ReactFC {...chartConfigs} />;
   }
 }
 

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,0 +1,137 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import FusionCharts from 'fusioncharts';
+import PowerCharts from 'fusioncharts/fusioncharts.powercharts';
+import ReactFC from 'react-fusioncharts';
+import moment from 'moment';
+import Loader from './Loader';
+
+import {
+  graphGetCurrencyGraph,
+  graphAddOpenGraph,
+  graphRemoveOpenGraph,
+} from '../reducers/_graph';
+
+const StyledGraph = styled.div`
+  background-color: #fff;
+  grid-row-start: 2;
+  grid-column-end: span 5;
+`;
+
+const StyledButton = styled.button`
+  font-size: 1rem;
+`;
+
+const StyledGraphContainer = styled.div`
+  text-align: center;
+  padding: 10px;
+`;
+
+class Graph extends Component {
+  state = {
+    open: false,
+  };
+
+  constructor(props) {
+    super(props);
+    this.toggleGraph = this.toggleGraph.bind(this);
+    this.getGraphData = this.getGraphData.bind(this);
+  }
+
+  toggleGraph() {
+    const newOpenState = !this.state.open;
+    this.setState({
+      open: newOpenState,
+    });
+    if (newOpenState) {
+      this.props.graphAddOpenGraph(this.props.symbol);
+      this.getGraphData();
+    } else {
+      this.props.graphRemoveOpenGraph(this.props.symbol);
+    }
+  }
+
+  getGraphData() {
+    this.props.graphGetCurrencyGraph(
+      this.props.symbol,
+      this.props.nativeCurrency,
+    );
+  }
+
+  render() {
+    const { open } = this.state;
+    const { graph, nativeCurrency, symbol } = this.props;
+
+    function renderGraphContainer() {
+      function renderContainerContent() {
+        if (graph.fetching) {
+          return <Loader size={20} color="black" background="white" />;
+        }
+        if (graph.error) {
+          return <span>{graph.error.message}</span>;
+        }
+        PowerCharts(FusionCharts);
+
+        const myDataSource = {
+          chart: {
+            caption: symbol,
+            subCaption: `worth in ${
+              nativeCurrency === 'GBP' || nativeCurrency === 'EUR'
+                ? 'USD'
+                : nativeCurrency
+            }`,
+            showValues: '0',
+          },
+          data: graph.points.map(point => {
+            return {
+              value: point[2],
+              label: moment(point[0])
+                .format('M/D/YYYY')
+                .toString(),
+            };
+          }),
+        };
+
+        const chartConfigs = {
+          type: 'spline',
+          width: '100%',
+          height: '400px',
+          dataFormat: 'json',
+          dataSource: myDataSource,
+        };
+
+        return <ReactFC {...chartConfigs} />;
+      }
+
+      return (
+        <StyledGraphContainer>{renderContainerContent()}</StyledGraphContainer>
+      );
+    }
+
+    return (
+      <StyledGraph>
+        <StyledButton onClick={this.toggleGraph}>
+          {open ? 'Hide' : 'Show'} graph
+        </StyledButton>
+        {open ? renderGraphContainer() : ''}
+      </StyledGraph>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => {
+  return {
+    graph: state.graph.graphs[props.symbol],
+    nativeCurrency: state.account.nativeCurrency,
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  {
+    graphGetCurrencyGraph,
+    graphAddOpenGraph,
+    graphRemoveOpenGraph,
+  },
+)(Graph);

--- a/src/components/NewsLink.js
+++ b/src/components/NewsLink.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+const moment = require('moment');
+
+const StyledNewsLink = styled.a`
+  padding: 10px;
+  display: block;
+
+  &:hover,
+  &:focus {
+    transform: translate(1px, 1px);
+  }
+
+  & img {
+    display: block;
+    margin-right: 5px;
+    height: 30px;
+  }
+
+  & h4 {
+    font-weight: 300;
+    font-size: 1rem;
+  }
+`;
+
+const StyledHeaderContainer = styled.div`
+  display: flex;
+  margin-bottom: 10px;
+`;
+
+const StyledDate = styled.p`
+  justify-content: flex-start !important;
+  font-size: 0.7rem !important;
+  opacity: 0.9;
+  margin-bottom: 10px;
+`;
+
+class NewsLink extends Component {
+  render() {
+    const { post } = this.props;
+
+    return (
+      <StyledNewsLink href={post.url}>
+        <StyledHeaderContainer>
+          <img src={`//${post.source.toLowerCase()}.com/favicon.ico`} alt="" />
+          <h4>{post.title}</h4>
+        </StyledHeaderContainer>
+        <StyledDate>{moment(post.data).format('YYYY-MM-DD hh:mm')}</StyledDate>
+        <p>{post.summary}</p>
+      </StyledNewsLink>
+    );
+  }
+}
+
+export default NewsLink;

--- a/src/components/NewsLink.js
+++ b/src/components/NewsLink.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 const StyledNewsLink = styled.a`
   padding: 10px;
   display: block;
+  width: 100%;
 
   &:hover,
   &:focus {

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -49,4 +49,7 @@ const reduxProps = ({ notification }) => ({
   message: notification.message,
 });
 
-export default connect(reduxProps, null)(Notification);
+export default connect(
+  reduxProps,
+  null,
+)(Notification);

--- a/src/components/TabMenu.js
+++ b/src/components/TabMenu.js
@@ -100,7 +100,7 @@ class TabMenu extends Component {
 
     this.state = {
       activeTab: 'BALANCES_TAB',
-      tabPosition: -87 + this._firstTabOffset()
+      tabPosition: -87 + this._firstTabOffset(),
     };
   }
 
@@ -175,8 +175,11 @@ class TabMenu extends Component {
   }
 
   _firstTabOffset() {
-    const tabCharSizes = ['account.tab_balances', 'account.tab_transactions', 'account.tab_interactions']
-        .map(resourceName => lang.t(resourceName).length);
+    const tabCharSizes = [
+      'account.tab_balances',
+      'account.tab_transactions',
+      'account.tab_interactions',
+    ].map(resourceName => lang.t(resourceName).length);
 
     return tabCharSizes[0] * 5;
   }

--- a/src/components/TokenInfo.js
+++ b/src/components/TokenInfo.js
@@ -137,7 +137,6 @@ class TokenInfo extends Component {
         return (
           <div>
             <StyledText>Could not find info for {token.symbol}</StyledText>
-            <Graph symbol={token.symbol} />
           </div>
         );
       }
@@ -155,7 +154,8 @@ class TokenInfo extends Component {
             <StyledText>{tokenInfo.info.num_holders_approx}</StyledText>
           </StyledTokenInfoLeft>
           <StyledGraphInfo>
-            <Graph symbol={token.symbol} />
+            <StyledHeading>Price chart</StyledHeading>
+            <StyledText>TBA</StyledText>
           </StyledGraphInfo>
           <StyledTokenInfoRow>
             <StyledLinksList>

--- a/src/components/TokenInfo.js
+++ b/src/components/TokenInfo.js
@@ -1,0 +1,226 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import Loader from './Loader';
+import { tokenGetTokenInfo } from '../reducers/_token';
+import { graphAddOpenGraph, graphRemoveOpenGraph } from '../reducers/_graph';
+import Graph from './Graph';
+import NewsLink from './NewsLink';
+import { colors, responsive } from '../styles';
+
+const StyledTokenInfoContainer = styled.div`
+  background-color: ${colors.white}
+  grid-row-start: 2;
+  grid-column-end: span 5;
+  text-align: left;
+`;
+
+const StyledTokenInfoGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 20px;
+`;
+
+const StyledTokenInfoLeft = styled.div`
+  justify-content: flex-start;
+  margin-bottom: 10px;
+  @media screen and (${responsive.sm.min}) {
+    flex: 1 0 50%;
+  }
+`;
+
+const StyledGraphInfo = styled.div`
+  text-align: center;
+  margin-bottom: 10px;
+  @media screen and (${responsive.sm.min}) {
+    flex: 0 1 50%;
+  }
+`;
+
+const StyledTokenInfoRow = styled.div`
+  flex-basis: 100%;
+`;
+
+const StyledButton = styled.button`
+  font-size: 1rem;
+  display: block;
+  width: 100%;
+  background-color: rgb(${colors.lightGrey});
+`;
+
+const StyledHeading = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 500;
+`;
+
+const StyledLinksList = styled.ul`
+  padding-bottom: 10px;
+  & li {
+    display: inline-block;
+
+    & i {
+      font-size: 1.5rem;
+      color: rgb(${colors.darkGrey});
+    }
+  }
+`;
+
+const StyledNewsList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  & li {
+    width: 100%;
+    display: inline-block;
+    margin-bottom: 5px;
+    border: 1px solid rgb(${colors.darkGrey});
+    @media screen and (${responsive.sm.min}) {
+      flex: 0 1 49%;
+    }
+  }
+`;
+
+const StyledText = styled.p`
+  padding-bottom: 10px;
+  justify-content: flex-start !important;
+`;
+
+const StyledDescriptiveList = styled.dl`
+  overflow: auto;
+  margin: 0 0 10px 0;
+  & dt,
+  & dd {
+    float: left;
+  }
+
+  & dt {
+    clear: both;
+  }
+`;
+
+class TokenInfo extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleInfo = this.toggleInfo.bind(this);
+    this.state = {
+      open: false,
+    };
+  }
+
+  toggleInfo() {
+    const { open } = this.state;
+    const {
+      token,
+      tokenGetTokenInfo,
+      graphAddOpenGraph,
+      graphRemoveOpenGraph,
+    } = this.props;
+    if (!open) {
+      tokenGetTokenInfo(token.address);
+      graphAddOpenGraph(token.symbol);
+    } else {
+      graphRemoveOpenGraph(token.symbol);
+    }
+
+    this.setState({
+      open: !open,
+    });
+  }
+
+  render() {
+    const { open } = this.state;
+    const { token, tokenInfo } = this.props;
+
+    function renderInfo() {
+      if (tokenInfo.error) {
+        return (
+          <div>
+            <StyledText>Could not find info for {token.symbol}</StyledText>
+            <Graph symbol={token.symbol} />
+          </div>
+        );
+      }
+
+      return (
+        <StyledTokenInfoGrid>
+          <StyledTokenInfoLeft>
+            <StyledHeading>General info</StyledHeading>
+            <StyledText>{tokenInfo.info.description}</StyledText>
+
+            <StyledHeading>Number of tokens</StyledHeading>
+            <StyledText>{tokenInfo.info.token_count}</StyledText>
+
+            <StyledHeading>Number of holders</StyledHeading>
+            <StyledText>{tokenInfo.info.num_holders_approx}</StyledText>
+          </StyledTokenInfoLeft>
+          <StyledGraphInfo>
+            <Graph symbol={token.symbol} />
+          </StyledGraphInfo>
+          <StyledTokenInfoRow>
+            <StyledLinksList>
+              {tokenInfo.info.links.map(link => {
+                return (
+                  <li key={link.title}>
+                    <a
+                      href={link.url}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                      title={link.title}
+                    >
+                      <i className={`zmdi ${link.icon} zmdi-hc-fw`} />
+                    </a>
+                  </li>
+                );
+              })}
+            </StyledLinksList>
+            <StyledHeading>Token smart contract:</StyledHeading>
+            <StyledDescriptiveList>
+              <dt>Address:</dt>
+              <dd>{tokenInfo.info.address}</dd>
+            </StyledDescriptiveList>
+            <StyledHeading>News:</StyledHeading>
+            <StyledNewsList>
+              {tokenInfo.info.last_posts.map(post => {
+                return (
+                  <li key={post.title}>
+                    <NewsLink post={post} />
+                  </li>
+                );
+              })}
+            </StyledNewsList>
+          </StyledTokenInfoRow>
+        </StyledTokenInfoGrid>
+      );
+    }
+
+    return (
+      <StyledTokenInfoContainer>
+        <StyledButton onClick={this.toggleInfo}>
+          {open ? 'Hide' : 'Show'} more info
+        </StyledButton>
+        {open && token.fetching ? (
+          <Loader size={20} color="black" background="white" />
+        ) : (
+          ''
+        )}
+        {open && !tokenInfo.fetching ? renderInfo() : ''}
+      </StyledTokenInfoContainer>
+    );
+  }
+}
+
+const reduxProps = (state, props) => {
+  return {
+    tokenInfo: state.token[props.token.address],
+  };
+};
+
+export default connect(
+  reduxProps,
+  {
+    tokenGetTokenInfo,
+    graphAddOpenGraph,
+    graphRemoveOpenGraph,
+  },
+)(TokenInfo);

--- a/src/components/Warning.js
+++ b/src/components/Warning.js
@@ -84,4 +84,7 @@ const reduxProps = ({ warning }) => ({
   active: warning.active,
 });
 
-export default connect(reduxProps, null)(Warning);
+export default connect(
+  reduxProps,
+  null,
+)(Warning);

--- a/src/handlers/api.js
+++ b/src/handlers/api.js
@@ -242,3 +242,12 @@ export const apiGetEthereumGraph = (symbol, nativeCurrency) => {
   // Get user chosen currency (selected upper right)
   return axios.get(`/candles/${symbol}${nativeCurrency}`);
 };
+
+/**
+ * @desc get info about a token address
+ * @return {Promise}
+ */
+export const apiGetTokenInfo = address => {
+  // Get user chosen currency (selected upper right)
+  return axios.get(`/api/tokenInfo?address=${address}`);
+};

--- a/src/handlers/api.js
+++ b/src/handlers/api.js
@@ -249,5 +249,8 @@ export const apiGetEthereumGraph = (symbol, nativeCurrency) => {
  */
 export const apiGetTokenInfo = address => {
   // Get user chosen currency (selected upper right)
-  return axios.get(`/api/tokenInfo?address=${address}`);
+  // return axios.get(`/api/tokenInfo?address=${address}`);
+  return axios.get(
+    `https://trivial.co/api/tokeninformation?token_address=${address}`,
+  );
 };

--- a/src/handlers/api.js
+++ b/src/handlers/api.js
@@ -233,3 +233,12 @@ export const apiShapeshiftGetQuotedPrice = (amount = '', exchangePair = '') =>
     amount,
     pair: exchangePair,
   });
+
+/**
+ * @desc get candles for Ethereum graph
+ * @return {Promise}
+ */
+export const apiGetEthereumGraph = (symbol, nativeCurrency) => {
+  // Get user chosen currency (selected upper right)
+  return axios.get(`/candles/${symbol}${nativeCurrency}`);
+};

--- a/src/layouts/base.js
+++ b/src/layouts/base.js
@@ -20,10 +20,11 @@ import { ledgerUpdateNetwork } from '../reducers/_ledger';
 import {
   accountChangeNativeCurrency,
   accountUpdateAccountAddress,
-  accountChangeLanguage
+  accountChangeLanguage,
 } from '../reducers/_account';
-import ReminderRibbon from '../components/ReminderRibbon';
+import { graphGetCurrencyGraphs } from '../reducers/_graph';
 import { colors, responsive } from '../styles';
+import ReminderRibbon from '../components/ReminderRibbon';
 import { resources } from '../languages';
 
 const StyledLayout = styled.div`
@@ -135,6 +136,7 @@ const BaseLayout = ({
   web3Available,
   online,
   modalOpen,
+  graphGetCurrencyGraphs,
   ...props
 }) => {
   const addresses = {};
@@ -145,11 +147,11 @@ const BaseLayout = ({
   }
   const languages = {};
   Object.keys(resources).forEach(resource => {
-      languages[resource] = {
-          code: resource,
-          description: resource.toUpperCase()
-      };
-  })
+    languages[resource] = {
+      code: resource,
+      description: resource.toUpperCase(),
+    };
+  });
   const showToolbar =
     window.location.pathname !== '/' &&
     (!metamaskFetching || !ledgerFetching) &&
@@ -185,11 +187,11 @@ const BaseLayout = ({
                   <StyledVerticalLine />
                 </Fragment>
               )}
-            <Dropdown 
-                displayKey={`description`}
-                selected={language}
-                options={languages}
-                onChange={accountChangeLanguage}
+            <Dropdown
+              displayKey={`description`}
+              selected={language}
+              options={languages}
+              onChange={accountChangeLanguage}
             />
             <StyledVerticalLine />
             <Dropdown
@@ -204,7 +206,10 @@ const BaseLayout = ({
               displayKey={`currency`}
               selected={nativeCurrency}
               options={nativeCurrencies}
-              onChange={accountChangeNativeCurrency}
+              onChange={newNativeCurrency => {
+                accountChangeNativeCurrency(newNativeCurrency);
+                graphGetCurrencyGraphs(newNativeCurrency);
+              }}
             />
           </StyledIndicators>
         </StyledHeader>
@@ -260,10 +265,14 @@ const reduxProps = ({ account, ledger, metamask, warning }) => ({
   online: warning.online,
 });
 
-export default connect(reduxProps, {
-  ledgerUpdateNetwork,
-  accountChangeNativeCurrency,
-  accountUpdateAccountAddress,
-  modalOpen,
-  accountChangeLanguage
-})(BaseLayout);
+export default connect(
+  reduxProps,
+  {
+    ledgerUpdateNetwork,
+    accountChangeNativeCurrency,
+    accountUpdateAccountAddress,
+    modalOpen,
+    accountChangeLanguage,
+    graphGetCurrencyGraphs,
+  },
+)(BaseLayout);

--- a/src/modals/DonationModal.js
+++ b/src/modals/DonationModal.js
@@ -537,15 +537,18 @@ const reduxProps = ({ modal, send, account }) => ({
   prices: account.prices,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-  sendModalInit,
-  sendUpdateGasPrice,
-  sendTransaction,
-  sendClearFields,
-  sendUpdateRecipient,
-  sendUpdateNativeAmount,
-  sendUpdateAssetAmount,
-  sendToggleConfirmationView,
-  notificationShow,
-})(DonationModal);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+    sendModalInit,
+    sendUpdateGasPrice,
+    sendTransaction,
+    sendClearFields,
+    sendUpdateRecipient,
+    sendUpdateNativeAmount,
+    sendUpdateAssetAmount,
+    sendToggleConfirmationView,
+    notificationShow,
+  },
+)(DonationModal);

--- a/src/modals/ExchangeModal.js
+++ b/src/modals/ExchangeModal.js
@@ -782,16 +782,19 @@ const reduxProps = ({ modal, exchange, account }) => ({
   nativeCurrency: account.nativeCurrency,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-  exchangeClearFields,
-  exchangeModalInit,
-  exchangeTransaction,
-  exchangeUpdateWithdrawalAmount,
-  exchangeUpdateDepositAmount,
-  exchangeUpdateDepositSelected,
-  exchangeUpdateWithdrawalSelected,
-  exchangeToggleConfirmationView,
-  exchangeMaxBalance,
-  notificationShow,
-})(ExchangeModal);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+    exchangeClearFields,
+    exchangeModalInit,
+    exchangeTransaction,
+    exchangeUpdateWithdrawalAmount,
+    exchangeUpdateDepositAmount,
+    exchangeUpdateDepositSelected,
+    exchangeUpdateWithdrawalSelected,
+    exchangeToggleConfirmationView,
+    exchangeMaxBalance,
+    notificationShow,
+  },
+)(ExchangeModal);

--- a/src/modals/ReceiveModal.js
+++ b/src/modals/ReceiveModal.js
@@ -113,6 +113,9 @@ const reduxProps = ({ account }) => ({
   accountType: account.accountType,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-})(ReceiveModal);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+  },
+)(ReceiveModal);

--- a/src/modals/SendModal.js
+++ b/src/modals/SendModal.js
@@ -728,17 +728,20 @@ const reduxProps = ({ modal, send, account }) => ({
   prices: account.prices,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-  sendModalInit,
-  sendUpdateGasPrice,
-  sendTransaction,
-  sendClearFields,
-  sendUpdateRecipient,
-  sendUpdateNativeAmount,
-  sendUpdateAssetAmount,
-  sendUpdateSelected,
-  sendMaxBalance,
-  sendToggleConfirmationView,
-  notificationShow,
-})(SendModal);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+    sendModalInit,
+    sendUpdateGasPrice,
+    sendTransaction,
+    sendClearFields,
+    sendUpdateRecipient,
+    sendUpdateNativeAmount,
+    sendUpdateAssetAmount,
+    sendUpdateSelected,
+    sendMaxBalance,
+    sendToggleConfirmationView,
+    notificationShow,
+  },
+)(SendModal);

--- a/src/modals/WalletConnectInit.js
+++ b/src/modals/WalletConnectInit.js
@@ -73,9 +73,12 @@ const reduxProps = ({ modal, walletconnect }) => ({
   webConnector: walletconnect.webConnector,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-  walletConnectInit,
-  walletConnectGetSession,
-  walletConnectClearFields,
-})(WalletConnectInit);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+    walletConnectInit,
+    walletConnectGetSession,
+    walletConnectClearFields,
+  },
+)(WalletConnectInit);

--- a/src/modals/index.js
+++ b/src/modals/index.js
@@ -96,8 +96,11 @@ const reduxProps = ({ modal }) => ({
   modal: modal.modal,
 });
 
-export default connect(reduxProps, {
-  modalClose,
-  sendClearFields,
-  exchangeClearFields,
-})(Modal);
+export default connect(
+  reduxProps,
+  {
+    modalClose,
+    sendClearFields,
+    exchangeClearFields,
+  },
+)(Modal);

--- a/src/pages/Ledger.js
+++ b/src/pages/Ledger.js
@@ -121,6 +121,9 @@ const reduxProps = ({ account, ledger }) => ({
   fetching: ledger.fetching,
 });
 
-export default connect(reduxProps, {
-  ledgerConnectInit,
-})(Ledger);
+export default connect(
+  reduxProps,
+  {
+    ledgerConnectInit,
+  },
+)(Ledger);

--- a/src/pages/Metamask.js
+++ b/src/pages/Metamask.js
@@ -81,8 +81,11 @@ const reduxProps = ({ account, metamask }) => ({
   fetching: metamask.fetching,
 });
 
-export default connect(reduxProps, {
-  metamaskUpdateMetamaskAccount,
-  metamaskConnectInit,
-  metamaskClearIntervals,
-})(Metamask);
+export default connect(
+  reduxProps,
+  {
+    metamaskUpdateMetamaskAccount,
+    metamaskConnectInit,
+    metamaskClearIntervals,
+  },
+)(Metamask);

--- a/src/pages/Wallet.js
+++ b/src/pages/Wallet.js
@@ -52,6 +52,9 @@ const reduxProps = ({ account }) => ({
   accountAddress: account.accountAddress,
 });
 
-export default connect(reduxProps, {
-  accountUpdateAccountAddress,
-})(Wallet);
+export default connect(
+  reduxProps,
+  {
+    accountUpdateAccountAddress,
+  },
+)(Wallet);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -260,7 +260,10 @@ Home.propTypes = {
   accountUpdateAccountAddress: PropTypes.func.isRequired,
 };
 
-export default connect(null, {
-  modalOpen,
-  accountUpdateAccountAddress,
-})(Home);
+export default connect(
+  null,
+  {
+    modalOpen,
+    accountUpdateAccountAddress,
+  },
+)(Home);

--- a/src/reducers/_account.js
+++ b/src/reducers/_account.js
@@ -304,14 +304,14 @@ export const accountUpdateAccountAddress = (accountAddress, accountType) => (
 };
 
 export const accountChangeLanguage = language => dispatch => {
-    //TODO: needs to trigger render after change
-    updateLanguage(language);
-    saveLocal('language', language);
-    dispatch({
-        type: ACCOUNT_CHANGE_LANGUAGE,
-        payload: { language }
-    });
-}
+  //TODO: needs to trigger render after change
+  updateLanguage(language);
+  saveLocal('language', language);
+  dispatch({
+    type: ACCOUNT_CHANGE_LANGUAGE,
+    payload: { language },
+  });
+};
 
 export const accountGetNativePrices = accountInfo => (dispatch, getState) => {
   const assetSymbols = accountInfo.assets.map(asset => asset.symbol);
@@ -456,8 +456,8 @@ export default (state = INITIAL_STATE, action) => {
     case ACCOUNT_CHANGE_LANGUAGE:
       return {
         ...state,
-        language: action.payload.language
-      }
+        language: action.payload.language,
+      };
     case ACCOUNT_GET_ACCOUNT_BALANCES_SUCCESS:
     case ACCOUNT_GET_ACCOUNT_BALANCES_FAILURE:
       return { ...state, fetching: false };

--- a/src/reducers/_graph.js
+++ b/src/reducers/_graph.js
@@ -1,0 +1,164 @@
+import { apiGetEthereumGraph } from '../handlers/api';
+
+const GRAPH_GET_GRAPH_REQUEST = 'graph/GRAPH_GET_GRAPH_REQUEST';
+const GRAPH_GET_GRAPH_SUCCESS = 'graph/GRAPH_GET_GRAPH_SUCCESS';
+const GRAPH_GET_GRAPH_FAILURE = 'graph/GRAPH_GET_GRAPH_FAILURE';
+
+const GRAPH_ADD_OPEN_GRAPH = 'graph/GRAPH_ADD_OPEN_GRAPH';
+const GRAPH_REMOVE_OPEN_GRAPH = 'graph/GRAPH_REMOVE_OPEN_GRAPH';
+
+// -- Actions --------------------------------------------------------------- //
+export const graphGetCurrencyGraphs = nativeCurrency => (
+  dispatch,
+  getState,
+) => {
+  const openGraphs = getState().graph.openGraphs;
+  openGraphs.forEach(symbol => {
+    dispatch({
+      type: GRAPH_GET_GRAPH_REQUEST,
+      payload: {
+        symbol: symbol,
+      },
+    });
+    apiGetEthereumGraph(symbol, nativeCurrency)
+      .then(({ data }) => {
+        dispatch({
+          type: GRAPH_GET_GRAPH_SUCCESS,
+          payload: {
+            symbol: symbol,
+            points: data,
+          },
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: GRAPH_GET_GRAPH_FAILURE,
+          payload: {
+            symbol: symbol,
+            error: {
+              message: `${symbol}${nativeCurrency} not listed on Binance`,
+            },
+          },
+        });
+      });
+  });
+};
+
+export const graphGetCurrencyGraph = (symbol, nativeCurrency) => (
+  dispatch,
+  getState,
+) => {
+  dispatch({
+    type: GRAPH_GET_GRAPH_REQUEST,
+    payload: {
+      symbol: symbol,
+    },
+  });
+  apiGetEthereumGraph(symbol, nativeCurrency)
+    .then(({ data }) => {
+      dispatch({
+        type: GRAPH_GET_GRAPH_SUCCESS,
+        payload: {
+          symbol: symbol,
+          points: data,
+        },
+      });
+    })
+    .catch(error => {
+      dispatch({
+        type: GRAPH_GET_GRAPH_FAILURE,
+        payload: {
+          symbol: symbol,
+          error: {
+            message: `${symbol}${nativeCurrency} not listed on Binance`,
+          },
+        },
+      });
+    });
+};
+
+export const graphAddOpenGraph = symbol => (dispatch, getState) => {
+  dispatch({
+    type: GRAPH_ADD_OPEN_GRAPH,
+    payload: {
+      symbol,
+    },
+  });
+};
+
+export const graphRemoveOpenGraph = symbol => (dispatch, getState) => {
+  dispatch({
+    type: GRAPH_REMOVE_OPEN_GRAPH,
+    payload: {
+      symbol,
+    },
+  });
+};
+
+const INITIAL_STATE = {
+  currentGraph: '',
+  openGraphs: [],
+  graphs: {
+    ETH: {
+      fetching: false,
+      points: [],
+    },
+  },
+};
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case GRAPH_GET_GRAPH_REQUEST:
+      return {
+        ...state,
+        graphs: {
+          ...state.graphs,
+          [action.payload.symbol]: {
+            ...state[action.payload.symbol],
+            fetching: true,
+          },
+        },
+      };
+    case GRAPH_GET_GRAPH_SUCCESS:
+      return {
+        ...state,
+        graphs: {
+          ...state.graphs,
+          [action.payload.symbol]: {
+            ...state[action.payload.symbol],
+            fetching: false,
+            points: action.payload.points,
+          },
+        },
+      };
+    case GRAPH_GET_GRAPH_FAILURE:
+      return {
+        ...state,
+        graphs: {
+          ...state.graphs,
+          [action.payload.symbol]: {
+            ...state[action.payload.symbol],
+            fetching: false,
+            error: action.payload.error,
+          },
+        },
+      };
+    case GRAPH_ADD_OPEN_GRAPH:
+      return {
+        ...state,
+        openGraphs: [...state.openGraphs, action.payload.symbol],
+      };
+    case GRAPH_REMOVE_OPEN_GRAPH:
+      return {
+        ...state,
+        openGraphs: state.openGraphs.filter(
+          symbol => symbol !== action.payload.symbol,
+        ),
+      };
+    case 'yolo': {
+      return state;
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/_graph.js
+++ b/src/reducers/_graph.js
@@ -155,9 +155,6 @@ export default (state = INITIAL_STATE, action) => {
           symbol => symbol !== action.payload.symbol,
         ),
       };
-    case 'yolo': {
-      return state;
-    }
     default:
       return state;
   }

--- a/src/reducers/_token.js
+++ b/src/reducers/_token.js
@@ -1,0 +1,70 @@
+import { apiGetTokenInfo } from '../handlers/api';
+
+const TOKEN_GET_TOKEN_INFO_REQUEST = 'token/GET_TOKEN_INFO_REQUEST';
+const TOKEN_GET_TOKEN_INFO_SUCCESS = 'token/GET_TOKEN_INFO_SUCCESS';
+const TOKEN_GET_TOKEN_INFO_FAILURE = 'token/GET_TOKEN_INFO_FAILURE';
+
+const INITIAL_STATE = [];
+
+export const tokenGetTokenInfo = address => (dispatch, getState) => {
+  // console.log('get token info: ', address);
+  dispatch({
+    type: TOKEN_GET_TOKEN_INFO_REQUEST,
+    payload: {
+      address: address,
+    },
+  });
+  apiGetTokenInfo(address)
+    .then(({ data }) => {
+      dispatch({
+        type: TOKEN_GET_TOKEN_INFO_SUCCESS,
+        payload: {
+          address: address,
+          info: data,
+        },
+      });
+    })
+    .catch(error => {
+      dispatch({
+        type: TOKEN_GET_TOKEN_INFO_FAILURE,
+        payload: {
+          address: address,
+          error: {
+            message: `No info found for ${address}`,
+          },
+        },
+      });
+    });
+};
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case TOKEN_GET_TOKEN_INFO_REQUEST:
+      return {
+        ...state,
+        [action.payload.address]: {
+          fetching: true,
+        },
+      };
+    case TOKEN_GET_TOKEN_INFO_SUCCESS:
+      return {
+        ...state,
+        [action.payload.address]: {
+          ...state[action.payload.address],
+          fetching: false,
+          info: action.payload.info,
+        },
+      };
+    case TOKEN_GET_TOKEN_INFO_FAILURE:
+      return {
+        ...state,
+        [action.payload.address]: {
+          ...state[action.payload.address],
+          fetching: false,
+          error: action.payload.error,
+        },
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,7 @@ import walletconnect from './_walletconnect';
 import notification from './_notification';
 import warning from './_warning';
 import graph from './_graph';
+import token from './_token';
 
 export default combineReducers({
   exchange,
@@ -21,4 +22,5 @@ export default combineReducers({
   warning,
   walletconnect,
   graph,
+  token,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import metamask from './_metamask';
 import walletconnect from './_walletconnect';
 import notification from './_notification';
 import warning from './_warning';
+import graph from './_graph';
 
 export default combineReducers({
   exchange,
@@ -19,4 +20,5 @@ export default combineReducers({
   notification,
   warning,
   walletconnect,
+  graph,
 });

--- a/src/styles.js
+++ b/src/styles.js
@@ -355,4 +355,6 @@ export const globalStyles = `
     display: inline-block;
     margin-top: 56px !important;
   }
+
+  @import url('https://cdnjs.cloudflare.com/ajax/libs/material-design-iconic-font/2.2.0/css/material-design-iconic-font.min.css');
 `;

--- a/src/views/Account/AccountBalances.js
+++ b/src/views/Account/AccountBalances.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import lang from '../../languages';
 import AssetIcon from '../../components/AssetIcon';
+import Graph from '../../components/Graph';
 import ToggleIndicator from '../../components/ToggleIndicator';
 import { ellipseText } from '../../helpers/utilities';
 import {
@@ -247,6 +248,7 @@ class AccountBalances extends Component {
             {ethereum.native ? ethereum.native.change.display : '———'}
           </StyledPercentage>
           <p>{ethereum.native ? ethereum.native.balance.display : '———'}</p>
+          <Graph symbol={'ETH'} />
         </StyledEthereum>
         {!!tokensAlwaysDisplay &&
           tokensAlwaysDisplay.map(token => (
@@ -269,6 +271,7 @@ class AccountBalances extends Component {
                 {token.native ? token.native.change.display : '———'}
               </StyledPercentage>
               <p>{token.native ? token.native.balance.display : '———'}</p>
+              <Graph symbol={token.symbol} />
             </StyledToken>
           ))}
         {!!tokensToggleDisplay.length &&
@@ -325,9 +328,13 @@ class AccountBalances extends Component {
 
 AccountBalances.propTypes = {
   accountInfo: PropTypes.object.isRequired,
+  // graphs: PropTypes.object.isRequired,
 };
-const reduxProps = ({ account }) => ({
-  accountInfo: account.accountInfo,
-});
 
-export default connect(reduxProps, null)(AccountBalances);
+const mapStateToProps = state => {
+  return {
+    accountInfo: state.account.accountInfo,
+  };
+};
+
+export default connect(mapStateToProps)(AccountBalances);

--- a/src/views/Account/AccountBalances.js
+++ b/src/views/Account/AccountBalances.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import lang from '../../languages';
 import AssetIcon from '../../components/AssetIcon';
-import Graph from '../../components/Graph';
+import EthereumInfo from '../../components/EthereumInfo';
+import TokenInfo from '../../components/TokenInfo';
 import ToggleIndicator from '../../components/ToggleIndicator';
 import { ellipseText } from '../../helpers/utilities';
 import {
@@ -248,7 +249,7 @@ class AccountBalances extends Component {
             {ethereum.native ? ethereum.native.change.display : '———'}
           </StyledPercentage>
           <p>{ethereum.native ? ethereum.native.balance.display : '———'}</p>
-          <Graph symbol={'ETH'} />
+          <EthereumInfo symbol={ethereum.symbol} />
         </StyledEthereum>
         {!!tokensAlwaysDisplay &&
           tokensAlwaysDisplay.map(token => (
@@ -271,7 +272,7 @@ class AccountBalances extends Component {
                 {token.native ? token.native.change.display : '———'}
               </StyledPercentage>
               <p>{token.native ? token.native.balance.display : '———'}</p>
-              <Graph symbol={token.symbol} />
+              <TokenInfo token={token} />
             </StyledToken>
           ))}
         {!!tokensToggleDisplay.length &&

--- a/src/views/Account/AccountInteractions.js
+++ b/src/views/Account/AccountInteractions.js
@@ -461,4 +461,7 @@ const reduxProps = ({ account }) => ({
   nativeCurrency: account.nativeCurrency,
 });
 
-export default connect(reduxProps, null)(AccountInteractions);
+export default connect(
+  reduxProps,
+  null,
+)(AccountInteractions);

--- a/src/views/Account/AccountTransactions.js
+++ b/src/views/Account/AccountTransactions.js
@@ -461,4 +461,7 @@ const reduxProps = ({ account }) => ({
   nativeCurrency: account.nativeCurrency,
 });
 
-export default connect(reduxProps, null)(AccountViewTransactions);
+export default connect(
+  reduxProps,
+  null,
+)(AccountViewTransactions);

--- a/src/views/Account/index.js
+++ b/src/views/Account/index.js
@@ -191,6 +191,9 @@ const reduxProps = ({ account }) => ({
   accountType: account.accountType,
 });
 
-export default connect(reduxProps, {
-  modalOpen,
-})(Account);
+export default connect(
+  reduxProps,
+  {
+    modalOpen,
+  },
+)(Account);


### PR DESCRIPTION
### PR Checklist (check all)

* [x] Updated `CHANGELOG.md` to describe the included fixes and changes made
* [x] Included issue number on the description of the PR
* [x] Commented on the relevant issue thread about this PR

### Issue number

#214 

### Changelog

* Proxy server to communicate with external APIs
* Add graphs from Binance
* Add token info from Trivial

Add a new pull request as the previous one was too chaotic IMO. It is still missing data like token info for ETH. I have yet to find a good resource for this. Any help will be appreciated.

@jinchung I have split the graph and token info to separate reducers to avoid contaminating `account.assets`. I'm keen to hear your thoughts on how to structure these data.
