### PR TITLE
Fix beta text display

### DIFF
--- a/src/layouts/base.js
+++ b/src/layouts/base.js
@@ -68,8 +68,8 @@ const StyledBeta = styled.div`
   margin: 0;
   position: absolute;
   top: 5.5px;
-  right: -36px;
-  width: 28px;
+  right: -40px;
+  display: inline-block;
   letter-spacing: 0.4px;
   font-size: 8px;
   font-weight: 500;


### PR DESCRIPTION

Currently, the text 'BETA' next to the logo isn't fully visible. The PR aims at fixing the display of the beta text.

### Before

![image](https://user-images.githubusercontent.com/7039523/41197640-50df9cca-6c2b-11e8-98b6-40853c3b2e93.png)

### After

![image](https://user-images.githubusercontent.com/7039523/41197643-559cff14-6c2b-11e8-92e6-430ddc0394fc.png)


### PR Checklist (check all)

* [ ] Updated `CHANGELOG.md` to describe the included fixes and changes made
* [ ] Included issue number on the description of the PR
* [ ] Commented on the relevant issue thread about this PR

### Issue number

<!--- Which issue(s) is this PR targeting -->

### Changelog

<!--- Paste here the added change logs added to the CHANGELOG.md -->
