### PR TITLE
Fix alt tag values for Ledger and Trezor logos

### DIFF
--- a/src/components/LedgerLogo.js
+++ b/src/components/LedgerLogo.js
@@ -13,7 +13,7 @@ const StyledLedgerLogo = styled.div`
 
 const LedgerLogo = ({ size, ...props }) => (
   <StyledLedgerLogo size={size} {...props}>
-    <img src={ledgerLogo} alt="metamask" />
+    <img src={ledgerLogo} alt="ledger" />
   </StyledLedgerLogo>
 );
 

--- a/src/components/TrezorLogo.js
+++ b/src/components/TrezorLogo.js
@@ -13,7 +13,7 @@ const StyledTrezorLogo = styled.div`
 
 const TrezorLogo = ({ size, ...props }) => (
   <StyledTrezorLogo size={size} {...props}>
-    <img src={trezorLogo} alt="metamask" />
+    <img src={trezorLogo} alt="trezor" />
   </StyledTrezorLogo>
 );
 


### PR DESCRIPTION

The `alt` tag values for Trezor logo and Ledger logo were both 'metamask'. I guess this is due to a copy+paste in haste. The PR fixes the alt tags for both the logos.

### PR Checklist (check all)

* [ ] Updated `CHANGELOG.md` to describe the included fixes and changes made
* [ ] Included issue number on the description of the PR
* [ ] Commented on the relevant issue thread about this PR
