### PR TITLE
Add autorefresh to accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added
 * Added Greek language translation
+* Added refresh balances/transactions every new block
 
 ### Changed
 

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -24,6 +24,13 @@ export const web3Instance = new Web3(
 );
 
 /**
+ * @desc web3 ws instance
+ */
+export const web3WSInstance = new Web3(
+  new Web3.providers.WebsocketProvider(`wss://mainnet.infura.io/_ws/`),
+);
+
+/**
  * @desc set a different web3 provider
  * @param {String}
  */


### PR DESCRIPTION
### PR Checklist (check all)

* [X] Updated `CHANGELOG.md` to describe the included fixes and changes made
* [X] Included issue number on the description of the PR
* [X] Commented on the relevant issue thread about this PR

### Issue number

https://github.com/balance-io/balance-manager/issues/318

### Changelog

Added refresh balances/transactions every new block

### Details
Add an additional web3 instance that uses infura's mainnet websocket
endpoint.  On every new block we simply refresh the balance,
transactions and unique tokens for a given account.

Few things to note:
- ACCOUNT_UPDATE_BALANCES_REQUEST wasn't being used so, removed it.
- accountClearIntervals looks like it was replaced in favor of
accountClearState, so removed that function as well.
- web3 v1.0.0-beta34 that we're using has a bug connecting to any
of the testnets on infura, downgrading to web3 v1.0.0-beta33 fixes
the problem if we want to have a network specific subscription
https://github.com/ethereum/web3.js/issues/1559
