### PR TITLE
Very small responsive UI tweak for StyledCard & WalletConnect button style consistency

### DIFF
--- a/src/modals/WalletConnectModal.js
+++ b/src/modals/WalletConnectModal.js
@@ -41,6 +41,15 @@ const StyledCenter = styled.div`
   align-items: center;
 `;
 
+const StyledButton = styled(Button)`
+  &:hover {
+    background: #4fa1ff;
+  }
+  &:active {
+    background: #408df7;
+  }
+`;
+
 class WalletConnectModal extends Component {
   componentDidMount() {
     this.props.walletConnectModalInit();
@@ -63,9 +72,9 @@ class WalletConnectModal extends Component {
             )}
           </StyledQRCodeWrapper>
           <StyledCenter>
-            <Button color="walletconnect" onClick={this.onClose}>
+            <StyledButton color="walletconnect" onClick={this.onClose}>
               {lang.t('button.close')}
-            </Button>
+            </StyledButton>
           </StyledCenter>
         </StyledContainer>
       </Card>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ const StyledCard = styled(Card)`
   background: #f5f6fa;
   display: block;
   margin-bottom: 18px;
-  min-height: 102px;
+  height: 102px;
   overflow: visible;
   width: 100%;
 `;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -144,10 +144,10 @@ const StyledWalletConnectLogo = styled.div`
 
 const StyledWalletConnectButton = ConnectButton.extend`
   &:hover {
-    background: #454852;
+    background: #4fa1ff;
   }
   &:active {
-    background: #2b2d33;
+    background: #408df7;
   }
 `;
 


### PR DESCRIPTION
In responsive mode the WalletConnect StyledCard height became taller than the other cards, this tiny CSS change did the trick in fixing it

### Issue number

#371

### Screenshots (Before)
![localhost_3000_ iphone 6_7_8 _before](https://user-images.githubusercontent.com/22222776/43660156-1126e65a-9756-11e8-8e7e-a5cc3a620f17.png)

### Screenshots (After)
![localhost_3000_ iphone 6_7_8 _after](https://user-images.githubusercontent.com/22222776/43660170-18a10a82-9756-11e8-8d8d-af93630d6894.png)
