### PR TITLE
Eip 1102 ethereum enable [wip]

### DIFF
--- a/src/reducers/_metamask.js
+++ b/src/reducers/_metamask.js
@@ -28,7 +28,7 @@ let accountInterval = null;
  */
 const getMetamaskNetwork = () =>
   new Promise((resolve, reject) => {
-    if (window.ethereum) {
+    if (window.ethereum || window.web) {
       window.ethereum
         .enable()
         .then(() => {
@@ -69,7 +69,7 @@ export const metamaskConnectInit = () => (dispatch, getState) => {
   if (accountAddress)
     dispatch(accountUpdateAccountAddress(accountAddress, 'METAMASK'));
   dispatch({ type: METAMASK_CONNECT_REQUEST });
-  if (window.ethereum) {
+  if (window.ethereum || window.web3) {
     getMetamaskNetwork()
       .then(network => {
         dispatch({ type: METAMASK_CONNECT_SUCCESS, payload: network });

--- a/src/reducers/_metamask.js
+++ b/src/reducers/_metamask.js
@@ -28,7 +28,7 @@ let accountInterval = null;
  */
 const getMetamaskNetwork = () =>
   new Promise((resolve, reject) => {
-    if (window.ethereum || window.web) {
+    if (window.ethereum) {
       window.ethereum
         .enable()
         .then(() => {
@@ -48,6 +48,18 @@ const getMetamaskNetwork = () =>
           console.error(err);
           reject();
         });
+    } else if (window.web3) {
+      window.web3.version.getNetwork((err, networkID) => {
+        if (err) {
+          console.error(err);
+          reject(err);
+        }
+        let networkIDList = {};
+        Object.keys(networkList).forEach(network => {
+          networkIDList[networkList[network].id] = network;
+        });
+        resolve(networkIDList[Number(networkID)] || null);
+      });
     }
   });
 

--- a/src/reducers/_metamask.js
+++ b/src/reducers/_metamask.js
@@ -28,18 +28,26 @@ let accountInterval = null;
  */
 const getMetamaskNetwork = () =>
   new Promise((resolve, reject) => {
-    if (typeof window.web3 !== 'undefined') {
-      window.web3.version.getNetwork((err, networkID) => {
-        if (err) {
+    if (window.ethereum) {
+      window.ethereum
+        .enable()
+        .then(() => {
+          window.web3.version.getNetwork((err, networkID) => {
+            if (err) {
+              console.error(err);
+              reject(err);
+            }
+            let networkIDList = {};
+            Object.keys(networkList).forEach(network => {
+              networkIDList[networkList[network].id] = network;
+            });
+            resolve(networkIDList[Number(networkID)] || null);
+          });
+        })
+        .catch(err => {
           console.error(err);
-          reject(err);
-        }
-        let networkIDList = {};
-        Object.keys(networkList).forEach(network => {
-          networkIDList[networkList[network].id] = network;
+          reject();
         });
-        resolve(networkIDList[Number(networkID)] || null);
-      });
     }
   });
 
@@ -61,7 +69,7 @@ export const metamaskConnectInit = () => (dispatch, getState) => {
   if (accountAddress)
     dispatch(accountUpdateAccountAddress(accountAddress, 'METAMASK'));
   dispatch({ type: METAMASK_CONNECT_REQUEST });
-  if (typeof window.web3 !== 'undefined') {
+  if (window.ethereum) {
     getMetamaskNetwork()
       .then(network => {
         dispatch({ type: METAMASK_CONNECT_SUCCESS, payload: network });


### PR DESCRIPTION
### Notes

This PR allows two things:

1. With a [version of MetaMask](https://github.com/MetaMask/metamask-extension/pull/4703#issuecomment-427062852) that includes the breaking change that'll occur in November, when connecting to Manager with MetaMask it will ask the user to accept the prompt generated by `ethereum.enable()`. If this prompt is rejected, the account cannot be accessed and the default error notification pops up. If accepted.
2. Currently, it still supports legacy dapp browsers and the current version of MetaMask, where it doesn't display a prompt for the user and flows as normal. Eventually, this support can be removed simply by deleting the `window.web3` checks in the reducers.

You can test it out with the linked version of MetaMask above (to try new flow) and your current version of MetaMask (to see it still works with current flow)

\* edit, run into some interesting problems with mobile dapp browsers:

1. With Status, you can use normally with current web3 provider injected automatically, but when you try the "Opt-in web3 provider" option it doesn't work like it does with the new MetaMask prompt.
2. With Trust, it doesn't work normally with current web3 provider at all 🤔

\* second edit, the shorthand way of doing the `window.web3` check didn't work with mobile dapp browsers, so I've done it the long way and now works find with Trust and Status. However, it still doesn't work with the "Opt-in web3 provider" option.

Anyone have any ideas?

### PR Checklist (check all)

* [ ] Updated `CHANGELOG.md` to describe the included fixes and changes made
* [x] Included issue number on the description of the PR
* [x] Commented on the relevant issue thread about this PR

### Issue number

#430 
